### PR TITLE
Refactored SplitCommandLine().

### DIFF
--- a/UnlockFile/MainWindow.xaml.cs
+++ b/UnlockFile/MainWindow.xaml.cs
@@ -109,26 +109,9 @@ namespace UnlockFile
 
             static (string fileName, string arguments) SplitCommandLine(string command)
             {
-                var isQuoted = false;
-                var i = 0;
-                for (; i < command.Length; i++)
-                {
-                    switch (command[i])
-                    {
-                        case ' ':
-                            if (!isQuoted)
-                            {
-                                return (command.Substring(0, i).Trim('"'), command.Substring(i).TrimStart());
-                            }
-                            break;
+                var arr = command.Trim().Split(command.Trim()[0] == '"' ? '"' : ' ', 2, StringSplitOptions.RemoveEmptyEntries);
 
-                        case '"':
-                            isQuoted = !isQuoted;
-                            break;
-                    }
-                }
-
-                return (command.Substring(0, i).Trim('"'), command.Substring(i));
+                return arr.Length > 1 ? (arr[0], arr[1]) : (arr[0], string.Empty);
             }
         }
 


### PR DESCRIPTION
According to my understanding:

1. Command can never be empty, no need for a check.
2. Trim() shouldn't be necessary, but why not...
3. Paths either starts with `"` or not.
4. Paths cannot contain `"`.
5. Paths that do not start with `"` cannot contain any spaces.
6. Only two parameters are of interest.

Have I missed anything?